### PR TITLE
Add GitHub Action to publish to PyPI

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -1,0 +1,37 @@
+name: Publish Python Package to PyPI
+
+on:
+  push:
+    tags:
+      - 'v*.*.*' # Trigger on version tags like v1.0.0, v0.1.0 etc.
+
+jobs:
+  build-and-publish:
+    name: Build and publish Python distribution to PyPI
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # Required to checkout the repository
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.9' # Matches python_requires from setup.py
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build twine
+
+    - name: Build package
+      # This will build both sdist and wheel by default into the 'dist' directory
+      run: python -m build
+
+    - name: Publish package to PyPI
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }} # Store your PyPI token as a secret in GitHub
+      run: twine upload dist/*


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to automate the publishing of a Python package to PyPI when a version tag is pushed. 

### New GitHub Actions Workflow:
* [`.github/workflows/publish_pypi.yml`](diffhunk://#diff-22966fe1865c208453d2318c03d1247f3106dad4d5e5ea4dbb3e2ebcf1d0065bR1-R37): Introduced a workflow named "Publish Python Package to PyPI" that triggers on version tags (e.g., `v1.0.0`). It includes steps to set up Python, install dependencies, build the package, and publish it to PyPI using a securely stored PyPI API token.